### PR TITLE
Feature/add types to general exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "module": "./dist/cdh-vue-lib.es.js",
   "exports": {
     ".": {
-      "import": "./dist/cdh-vue-lib.es.js"
+      "import": ["./dist/cdh-vue-lib.es.js", "./dist/index.d.ts"]
     },
     "./components": {
       "import": "./dist/cdh-vue-lib.components.es.js"


### PR DESCRIPTION
I'm not sure if this is the correct solution to the problem I'm having, but currently, all my imports from this library in the DIAPP are untyped, and this error is shown.

![image](https://github.com/CentreForDigitalHumanities/Vue-lib/assets/73882506/7eb90979-ad2c-4500-85e9-172a5641e653)


Adding the types file explicitly to `exports`, as suggested by the error message, solves this issue.