### PR TITLE
Use correct version for UU-Bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "types": "vue-tsc --emitDeclarationOnly"
   },
   "dependencies": {
-    "uu-bootstrap": "git+ssh://git@github.com/UtrechtUniversity/UU-Bootstrap.git#v1.5.0-alpha.1",
+    "uu-bootstrap": "git+https://github.com/UtrechtUniversity/UU-Bootstrap.git#v1.5.0-alpha.1",
     "uuid": "^9.0.0",
     "vue-i18n": "9"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "types": "vue-tsc --emitDeclarationOnly"
   },
   "dependencies": {
-    "uu-bootstrap": "git+ssh://git@github.com/UtrechtUniversity/UU-Bootstrap.git#1.5.0-alpha.1",
+    "uu-bootstrap": "git+ssh://git@github.com/UtrechtUniversity/UU-Bootstrap.git#v1.5.0-alpha.1",
     "uuid": "^9.0.0",
     "vue-i18n": "9"
   },


### PR DESCRIPTION
I'm not sure how this ever worked. My best guess is that all projects that use the latest version of Vue-lib also have a direct dependency on UU-Bootstrap (with the correct version used).